### PR TITLE
Fix #3, handle null bulk string correctly

### DIFF
--- a/reader_it_test.go
+++ b/reader_it_test.go
@@ -28,6 +28,16 @@ func TestReader_IT_Test(t *testing.T) {
 		t.Fatalf("expect an error but got %+v", helloErrorResp)
 	}
 
+	// get a non-existing value with RESP2 to test null bulk string
+	w.WriteCommand("GET", "NON_EXIST")
+	resp, _, err := r.ReadValue()
+	if err != nil {
+		t.Fatalf("failed to GET")
+	}
+	if resp.SmartResult() != nil {
+		t.Fatalf("expect get nil but got %+v", resp)
+	}
+
 	// send protocol version 3, get a map result
 	w.WriteCommand("HELLO", "3")
 	helloResp, _, err := r.ReadValue()
@@ -41,7 +51,7 @@ func TestReader_IT_Test(t *testing.T) {
 
 	// set and get
 	w.WriteCommand("SET", "A", "123")
-	resp, _, err := r.ReadValue()
+	resp, _, err = r.ReadValue()
 	if err != nil {
 		t.Fatalf("failed to SET")
 	}

--- a/resp3_test.go
+++ b/resp3_test.go
@@ -84,9 +84,18 @@ func TestNull(t *testing.T) {
 	v := &Value{
 		Type: TypeNull,
 	}
-
 	s := v.ToRESP3String()
 	expected := "_\r\n"
+	if s != expected {
+		t.Errorf("expected %s but got %s", expected, s)
+	}
+
+	v = &Value{
+		Type:           TypeBlobString,
+		NullBulkString: true,
+	}
+	s = v.ToRESP3String()
+	expected = "$-1\r\n"
 	if s != expected {
 		t.Errorf("expected %s but got %s", expected, s)
 	}


### PR DESCRIPTION
This PR fixes #3. To make it possible to distinguish between RESP3 null and RESP2 null bulk string, I added a `NullBulkString` flag and set it to True when it's the special case like that.